### PR TITLE
feat: add denolus css compiler to Ogone

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -17,4 +17,9 @@ export {
     fail,
   } from "https://raw.githubusercontent.com/denoland/deno/master/std/testing/asserts.ts";
 export { compile as sassCompiler } from "https://deno.land/x/sass/mod.ts";
-export { compile as denolusCompiler } from "https://raw.githubusercontent.com/divy-work/denolus/master/mod.ts"
+import { parse } from "https://raw.githubusercontent.com/divy-work/denolus/master/src/parser/index.ts"
+import { compile } from "https://raw.githubusercontent.com/divy-work/denolus/master/src/compiler/index.ts"
+
+export function denolusCompiler(code: string) {
+  return compile(parse(code));
+}

--- a/deps.ts
+++ b/deps.ts
@@ -17,3 +17,4 @@ export {
     fail,
   } from "https://raw.githubusercontent.com/denoland/deno/master/std/testing/asserts.ts";
 export { compile as sassCompiler } from "https://deno.land/x/sass/mod.ts";
+export { compile as denolusCompiler } from "https://raw.githubusercontent.com/divy-work/denolus/master/mod.ts"

--- a/src/ogone/compilation/inspection/styles.ts
+++ b/src/ogone/compilation/inspection/styles.ts
@@ -1,5 +1,5 @@
 import scopeCSS from "../../../../lib/html-this/scopeCSS.ts";
-import { sassCompiler } from "../../../../deps.ts";
+import { sassCompiler, denolusCompiler } from "../../../../deps.ts";
 import { Bundle } from "../../../../.d.ts";
 
 export default function oRenderStyles(bundle: Bundle) {
@@ -20,6 +20,9 @@ export default function oRenderStyles(bundle: Bundle) {
               indented_syntax: false,
               include_paths: []
             }).result;
+            break;
+          case "denolus":
+            compiledCss = denolusCompiler(element.childNodes[0].rawText);
             break;
           default:
             compiledCss = element.childNodes[0].rawText;


### PR DESCRIPTION
Adds Denolus to Ogone.
Note: This has not been tested in a live example.